### PR TITLE
Add overridden test client and example.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,11 @@ You can use a symmetric key or asymmetric key pair. In the simplest case, you ca
 
 No library is provided for consuming the JWT, federated services should use available JWT libraries for verifying and extracting fields from the JWT.
 
+Django Tests
+------------
+
+When using Django's test client in unit tests, the login() method bypasses middleware and sets the session cookie directly. If you are using ``django-session-jwt`` this may cause tests to fail. In this case, you can use an alternative test client ``django_session_jwt.test.Client`` that overrides the ``login()`` method to convert the sessoin cookie to a JWT.
+
 Development
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ Django Tests
 
 When using Django's test client in unit tests, the login() method bypasses middleware and sets the session cookie directly. If you are using ``django-session-jwt`` this may cause tests to fail. In this case, you can use an alternative test client ``django_session_jwt.test.Client`` that overrides the ``login()`` method to convert the sessoin cookie to a JWT.
 
+Here is an `example <django_session_jwt/tests.py#L85>`_ of using this test client.
+
 Development
 -----------
 

--- a/django_session_jwt/middleware/__init__.py
+++ b/django_session_jwt/middleware/__init__.py
@@ -1,1 +1,1 @@
-from .session import SessionMiddleware
+from .session import SessionMiddleware, convert_cookie

--- a/django_session_jwt/middleware/__init__.py
+++ b/django_session_jwt/middleware/__init__.py
@@ -1,1 +1,1 @@
-from .session import SessionMiddleware, convert_cookie
+from .session import SessionMiddleware, convert_cookie, verify_jwt

--- a/django_session_jwt/test.py
+++ b/django_session_jwt/test.py
@@ -4,8 +4,7 @@ from django.conf import settings
 from django.test.client import Client as BaseClient
 from django.contrib.auth import SESSION_KEY, get_user_model
 
-from django_session_jwt.middleware import convert_cookie
-from django_session_jwt.middleware.session import verify_jwt
+from django_session_jwt.middleware import convert_cookie, verify_jwt
 
 
 User = get_user_model()

--- a/django_session_jwt/test.py
+++ b/django_session_jwt/test.py
@@ -1,7 +1,10 @@
+from importlib import import_module
+
+from django.conf import settings
 from django.test.client import Client as BaseClient
 from django.contrib.auth import SESSION_KEY, get_user_model
 
-from django_session_jwt.middleware import convert_cookie
+from django_session_jwt.middleware import convert_cookie, verify_jwt
 
 
 User = get_user_model()
@@ -14,3 +17,19 @@ class Client(BaseClient):
             user = User.objects.get(id=int(self.session[SESSION_KEY]))
             convert_cookie(self.cookies, user)
         return ret
+
+    @property
+    def session(self):
+        """
+        Obtains the current session variables.
+        """
+        engine = import_module(settings.SESSION_ENGINE)
+        cookie = self.cookies.get(settings.SESSION_COOKIE_NAME)
+        if cookie:
+            sk = verify_jwt(cookie.value).get('sk', cookie.value)
+            return engine.SessionStore(sk)
+
+        session = engine.SessionStore()
+        session.save()
+        self.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
+        return session

--- a/django_session_jwt/test.py
+++ b/django_session_jwt/test.py
@@ -4,7 +4,8 @@ from django.conf import settings
 from django.test.client import Client as BaseClient
 from django.contrib.auth import SESSION_KEY, get_user_model
 
-from django_session_jwt.middleware import convert_cookie, verify_jwt
+from django_session_jwt.middleware import convert_cookie
+from django_session_jwt.middleware.session import verify_jwt
 
 
 User = get_user_model()

--- a/django_session_jwt/test.py
+++ b/django_session_jwt/test.py
@@ -1,0 +1,16 @@
+from django.test.client import Client as BaseClient
+from django.contrib.auth import SESSION_KEY, get_user_model
+
+from django_session_jwt.middleware import convert_cookie
+
+
+User = get_user_model()
+
+
+class Client(BaseClient):
+    def login(self, **credentials):
+        ret = super(Client, self).login(**credentials)
+        if ret:
+            user = User.objects.get(id=int(self.session[SESSION_KEY]))
+            convert_cookie(self.cookies, user)
+        return ret

--- a/django_session_jwt/tests.py
+++ b/django_session_jwt/tests.py
@@ -87,3 +87,7 @@ class TestClientTestCase(BaseTestCase):
         "Test logging in a user using Client.login()"
         ret = self.client.login(username='john', password='password')
         self.assertTrue(ret)
+        fields = session.verify_jwt(self.client.cookies[settings.SESSION_COOKIE_NAME].value)
+        self.assertTrue('id' in fields)
+        self.assertTrue('username' in fields)
+        self.assertTrue('email' in fields)

--- a/django_session_jwt/tests.py
+++ b/django_session_jwt/tests.py
@@ -8,10 +8,11 @@ from os.path import dirname, normpath
 from os.path import join as pathjoin
 
 from django.conf import settings
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.contrib.auth import get_user_model
 
-from .middleware import session
+from django_session_jwt.middleware import session
+from django_session_jwt.test import Client
 
 
 User = get_user_model()
@@ -62,7 +63,7 @@ class ViewTestCase(BaseTestCase):
     """
 
     def test_login(self):
-        "Test logging in a user"
+        "Test logging in a user via POST"
         r = self.client.post('/login/', {'username': 'john', 'password': 'password'})
         self.assertEqual(r.status_code, 200)
         fields = session.verify_jwt(r.cookies[settings.SESSION_COOKIE_NAME].value)
@@ -79,3 +80,10 @@ class ViewTestCase(BaseTestCase):
         json = r.json()
         self.assertEqual(json['a'], '12345')
         self.assertEqual(json['b'], 'abcde')
+
+
+class TestClientTestCase(BaseTestCase):
+    def test_login(self):
+        "Test logging in a user using Client.login()"
+        ret = self.client.login(username='john', password='password')
+        self.assertTrue(ret)


### PR DESCRIPTION
Add a test client that handles JWT during Django unit tests. Use the login() method of this client in a test. Update documentation to mention this test client and it's usage.