### PR TITLE
Decouple JWT and session expiration.

### DIFF
--- a/django_session_jwt/middleware/session.py
+++ b/django_session_jwt/middleware/session.py
@@ -1,4 +1,6 @@
 import logging
+import time
+
 from datetime import datetime, timedelta
 
 from os.path import exists as pathexists
@@ -162,7 +164,8 @@ class SessionMiddleware(BaseSessionMiddleware):
 
         # Determine if JWT is more than halfway through it's lifetime.
         expires = getattr(request, 'session', {}).get('jwt', {}).get('exp', None)
-        halflife = expires and expires <= (datetime.now() + timedelta(seconds=EXPIRES / 2)).timestamp()
+        halftime = time.mktime((datetime.now() + timedelta(seconds=EXPIRES / 2)).timetuple())
+        halflife = expires and expires <= halftime
 
         # Behave the same as contrib.sessions, only recreate the JWT if the session
         # was modified or SESSION_SAVE_EVERY_REQUEST is enabled.

--- a/django_session_jwt/settings.py
+++ b/django_session_jwt/settings.py
@@ -122,5 +122,6 @@ DJANGO_SESSION_JWT = {
     'KEY': SECRET_KEY,
     # The default, uncomment to override:
     # 'SESSION_FIELD': 'sk',
+    'EXPIRES': 60 * 60 * 8,
 }
 

--- a/django_session_jwt/test.py
+++ b/django_session_jwt/test.py
@@ -1,7 +1,5 @@
 from importlib import import_module
 
-from jwt.exceptions import DecodeError
-
 from django.conf import settings
 from django.test.client import Client as BaseClient
 from django.contrib.auth import SESSION_KEY, get_user_model

--- a/django_session_jwt/test.py
+++ b/django_session_jwt/test.py
@@ -1,5 +1,7 @@
 from importlib import import_module
 
+from jwt.exceptions import DecodeError
+
 from django.conf import settings
 from django.test.client import Client as BaseClient
 from django.contrib.auth import SESSION_KEY, get_user_model
@@ -26,8 +28,12 @@ class Client(BaseClient):
         engine = import_module(settings.SESSION_ENGINE)
         cookie = self.cookies.get(settings.SESSION_COOKIE_NAME)
         if cookie:
-            sk = verify_jwt(cookie.value).get('sk', cookie.value)
-            return engine.SessionStore(sk)
+            try:
+                sk = verify_jwt(cookie.value).get('sk', cookie.value)
+                return engine.SessionStore(sk)
+
+            except DecodeError:
+                pass
 
         session = engine.SessionStore()
         session.save()

--- a/django_session_jwt/test.py
+++ b/django_session_jwt/test.py
@@ -28,12 +28,8 @@ class Client(BaseClient):
         engine = import_module(settings.SESSION_ENGINE)
         cookie = self.cookies.get(settings.SESSION_COOKIE_NAME)
         if cookie:
-            try:
-                sk = verify_jwt(cookie.value).get('sk', cookie.value)
-                return engine.SessionStore(sk)
-
-            except DecodeError:
-                pass
+            sk = verify_jwt(cookie.value).get('sk', cookie.value)
+            return engine.SessionStore(sk)
 
         session = engine.SessionStore()
         session.save()

--- a/django_session_jwt/tests.py
+++ b/django_session_jwt/tests.py
@@ -1,3 +1,5 @@
+import time
+
 try:
     from unittest import mock
 
@@ -93,8 +95,10 @@ class ViewTestCase(BaseTestCase):
         fields = session.verify_jwt(r.cookies[settings.SESSION_COOKIE_NAME].value)
         # JWT expiration should exceed cookie expiration.
         expires = r.cookies[settings.SESSION_COOKIE_NAME]['expires']
+        # Normalize date format (different Django versions use - or <space>)
+        expires = expires.replace('-', ' ')
         # format: "Fri, 14 Aug 2020 19:27:28 GMT"
-        expires = int(datetime.strptime(expires, '%a, %d %b %Y %H:%M:%S %Z').timestamp())
+        expires = int(time.mktime(datetime.strptime(expires, '%a, %d %b %Y %H:%M:%S %Z').timetuple()))
         self.assertGreater(expires, fields['exp'])
         
 


### PR DESCRIPTION
This adds a setting to JWT middleware that allows the token expiration to be set independently of the session expiration. The token is renewed if the current time exceeds half of it's lifetime. For example, if a token expires in 8h, it will be refreshed after 4h. The session expiration now solely controls the session lifetime. The token expiration is ONLY to defend against tokens being compromised and remaining valid for eternity.

Closes #8