### PR TITLE
Allow JWT fields to come from a callable.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,10 @@ Then modify settings.py:
             ...
         ],
 
+        # You can also populate the JWT fields by configuring your own callable. The
+        # callable should return a dictionary.
+        'CALLABLE': 'some.module.with.a.function',
+
         # KEY can also be a tuple in order to specify public and private keys.
         'KEY': 'string value or path to PEM key file',
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Then modify settings.py:
         ],
 
         # You can also populate the JWT fields by configuring your own callable. The
-        # callable should return a dictionary.
+        # callable should return a dictionary. The function should optionally accept user.
         'CALLABLE': 'some.module.with.a.function',
 
         # KEY can also be a tuple in order to specify public and private keys.

--- a/django_session_jwt/__init__.py
+++ b/django_session_jwt/__init__.py
@@ -1,0 +1,2 @@
+def get_fields(user=None):
+    return { 'foo': 'bar' }

--- a/django_session_jwt/settings.py
+++ b/django_session_jwt/settings.py
@@ -119,6 +119,7 @@ DJANGO_SESSION_JWT = {
         ('username', 'u', 'username'),
         ('email', 'e', 'email'),
     ],
+    'CALLABLE': 'django_session_jwt.get_fields',
     'KEY': SECRET_KEY,
     # The default, uncomment to override:
     # 'SESSION_FIELD': 'sk',

--- a/django_session_jwt/tests.py
+++ b/django_session_jwt/tests.py
@@ -77,6 +77,7 @@ class ViewTestCase(BaseTestCase):
         self.assertTrue('username' in fields) # long form
         self.assertTrue('e' in fields)        # short form
         self.assertTrue('email' in fields)    # long form
+        self.assertTrue('foo' in fields)      # from callable
 
     def test_session(self):
         "Test persisting session data"
@@ -114,3 +115,4 @@ class TestClientTestCase(BaseTestCase):
         self.assertTrue('username' in fields) # long form
         self.assertTrue('e' in fields)        # short form
         self.assertTrue('email' in fields)    # long form
+        self.assertTrue('foo' in fields)      # from callable


### PR DESCRIPTION
Allow settings to provide a callable that can return a dictionary to be merged into JWT.