### PR TITLE
Always generate a JWT to persist the session

### DIFF
--- a/django_session_jwt/middleware/session.py
+++ b/django_session_jwt/middleware/session.py
@@ -180,9 +180,8 @@ class SessionMiddleware(BaseSessionMiddleware):
                 user_id = request.session['jwt']['user_id']
                 user = User.objects.get(id=user_id)
             except (KeyError, User.DoesNotExist):
-                # Unable to determine the user. Allow the base class
-                # implementation to handle the response.
-                return super(SessionMiddleware, self).process_response(request, response)
+                # Unable to determine the user. ID will not be set in the JWT.
+                user = None
         else:
             user = request.user
 


### PR DESCRIPTION
Using the base class implementation causes the session key to be put into the `sessionid` cookie. This causes the request processing to create a new session which loses any data in the previous session. A JWT can be created with no user ID which was happening originally and works to persist the session properly.