### PR TITLE
Remove unsupported python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - '2.7'
   - '3.6'
   - '3.7'
   - '3.8'
@@ -19,15 +18,6 @@ install:
 script: make ci
 after_success: coveralls
 jobs:
-  exclude:
-    - python: '2.7'
-      env: DJANGO=2.0
-    - python: '2.7'
-      env: DJANGO=2.2
-    - python: '2.7'
-      env: DJANGO=3.0
-    - python: '2.7'
-      env: DJANGO=3.1
   include:
     - stage: deploy
       python: '3.8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - '2.7'
-  - '3.4'
-  - '3.5'
   - '3.6'
+  - '3.7'
+  - '3.8'
 env:
   - DJANGO=1.11
   - DJANGO=2.0
@@ -28,19 +28,9 @@ jobs:
       env: DJANGO=3.0
     - python: '2.7'
       env: DJANGO=3.1
-    - python: '3.4'
-      env: DJANGO=2.2
-    - python: '3.4'
-      env: DJANGO=3.0
-    - python: '3.4'
-      env: DJANGO=3.1
-    - python: '3.5'
-      env: DJANGO=3.0
-    - python: '3.5'
-      env: DJANGO=3.1
   include:
     - stage: deploy
-      python: '3.6'
+      python: '3.8'
       env: DJANGO=3.0
       script: echo "Deploying to PyPI ..."
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - DJANGO=3.1
 
 install:
-  - python -m pip install -U pip==18.0
+  - python -m pip install -U pip~=21.0
   - pipenv install --dev --skip-lock
   - pip install --timeout=30 -q Django==$DJANGO
   - pip install --timeout=30 -q -e .

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 freezegun = "*"
 
 [packages]
-pyjwt = "*"
+pyjwt = "<2.0"
 django = "*"
 cryptography = "*"
 mock = "*"
@@ -16,4 +16,4 @@ coverage = "*"
 pylint = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.8"

--- a/django_session_jwt/tests.py
+++ b/django_session_jwt/tests.py
@@ -1,10 +1,5 @@
 import time
-
-try:
-    from unittest import mock
-
-except ImportError:
-    import mock
+from unittest import mock
 
 from os.path import dirname, normpath
 from os.path import join as pathjoin


### PR DESCRIPTION
Python 2.7, 3.4, and 3.5 are all EOL. They are causing issues keeping dependencies up to date and should be removed. `pyjwt` had a significant breaking change release at `2.0` and needs to be held back until the code has been updated.