### PR TITLE
Handle early Responses

### DIFF
--- a/django_session_jwt/middleware/session.py
+++ b/django_session_jwt/middleware/session.py
@@ -172,7 +172,7 @@ class SessionMiddleware(BaseSessionMiddleware):
             request.session['jwt'] = fields
 
     def process_response(self, request, response):
-        if not request.user.is_authenticated:
+        if not hasattr(request, 'user') or not request.user.is_authenticated:
             # The user is unauthenticated. Try to determine the user by the
             # session JWT
             User = get_user_model()


### PR DESCRIPTION
Responses can be returned by middleware before reaching AuthenticationMiddleware - in these cases there is no request.user attribute.

This happens with Django's default `MIDDLEWARE` ordering if the current host is disallowed (not in `ALLOWED_HOSTS`) for instance.