### PR TITLE
Remove unsupported python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         django-version: [ '1.11', '2.0', '2.1', '2.2', '3.0', '3.1', '3.2' ]
     steps:
       - name: Check out code


### PR DESCRIPTION
Python 3.6 is no longer supported in GitHub actions